### PR TITLE
added logic for pagination

### DIFF
--- a/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
+++ b/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
@@ -3,7 +3,11 @@ package com.apptware.interview.stream.impl;
 import com.apptware.interview.stream.DataReader;
 import com.apptware.interview.stream.PaginationService;
 import jakarta.annotation.Nonnull;
+
+import java.util.*;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,8 +38,10 @@ class DataReaderImpl implements DataReader {
     // Placeholder for paginated data fetching logic
     // The candidate will add the actual implementation here
 
-    Stream<String> dataStream =
-        Stream.empty(); // Temporary, will be replaced by the actual data stream
-    return dataStream.peek(item -> log.info("Fetched Item: {}", item));
+    return Stream.iterate(0, page -> page + 1)
+            .map(page -> paginationService.getPaginatedData(page + 1, 100))
+            .takeWhile(pageData -> !pageData.isEmpty())
+            .flatMap(Collection::stream)
+            .peek(item -> log.info("Fetched Item: {}", item));
   }
 }


### PR DESCRIPTION
The provided code implements a data fetching mechanism, specifically designed for paginated data.

The fetchPaginatedDataAsStream method creates a stream that fetches data in paginated chunks on demand, efficiently processing large datasets in small, manageable batches. 

Breakdown:

Initialize Page Stream: Stream.iterate(0, page -> page + 1) generates an infinite stream of page numbers, starting from 0.

Fetch Each Page: Each page number is mapped to a call to paginationService.getPaginatedData(page + 1, 100), retrieving a list of items for that page with a fixed page size of 100.

Stop When No More Data: .takeWhile(pageData -> !pageData.isEmpty()) stops fetching when an empty page is encountered, signaling no more data.

Flatten Pages to Single Stream: .flatMap(Collection::stream) merges each list of items into a continuous stream of individual items, rather than separate pages.

Log Each Item: .peek(item -> log.info("Fetched Item: {}", item)) logs each item as it’s processed, aiding in monitoring and debugging.